### PR TITLE
Don't run npm run build on postinstall

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fluidlint",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fluidlint",
-  "version": "1.1.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,10 +9,9 @@
     "build": "babel 'src/*.js' --out-dir dist --ignore 'src/*.test.js'",
     "start": "babel 'src/*.js' --out-dir dist --ignore 'src/*.test.js' --watch",
     "test": "jest",
-    "postinstall": "npm run build",
     "check-lint": "prettier --list-different '**/*.js' && eslint '**/*.js'",
     "lint": "prettier --write '**/*.js' && eslint --fix '**/*.js'",
-    "prepublishOnly": "npm ci && npm run check-lint && npm test",
+    "prepublishOnly": "npm ci && npm run build && npm run check-lint && npm test",
     "postpublish": "git tag v$npm_package_version && git push --tags"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fluidlint",
-  "version": "1.1.0",
+  "version": "1.0.1",
   "description": "CLI that ensures that Liquid features that aren't supported by Fluid are not used.",
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fluidlint",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "CLI that ensures that Liquid features that aren't supported by Fluid are not used.",
   "keywords": [],
   "author": "",


### PR DESCRIPTION
I forgot that `postinstall` would also get run by consumers of this library, which we don't want

Draft release notes for `1.0.1`: https://github.com/cloudfour/fluidlint/releases/tag/untagged-62cbb7034348904f6ffe