### PR TITLE
Move ansi-colors to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fluidlint",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -322,8 +322,7 @@
     "ansi-colors": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.1.tgz",
-      "integrity": "sha512-Xt+zb6nqgvV9SWAVp0EG3lRsHcbq5DDgqjPPz6pwgtj6RKz65zGXMNa82oJfOSBA/to6GmRP7Dr+6o+kbApTzQ==",
-      "dev": true
+      "integrity": "sha512-Xt+zb6nqgvV9SWAVp0EG3lRsHcbq5DDgqjPPz6pwgtj6RKz65zGXMNa82oJfOSBA/to6GmRP7Dr+6o+kbApTzQ=="
     },
     "ansi-escapes": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "@babel/core": "^7.1.2",
     "@babel/plugin-transform-modules-commonjs": "^7.1.0",
     "@cloudfour/eslint-config": "^1.0.0",
-    "ansi-colors": "^3.2.1",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^23.6.0",
     "eslint": "^5.8.0",
@@ -43,6 +42,7 @@
     "prettier": "^1.14.3"
   },
   "dependencies": {
+    "ansi-colors": "^3.2.1",
     "ansi-escapes": "^3.1.0",
     "fast-glob": "^2.2.3",
     "log-symbols": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fluidlint",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "CLI that ensures that Liquid features that aren't supported by Fluid are not used.",
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Previously `ansi-colors` was not being installed, which means that it failed because of an incompatible version of `ansi-colors` being installed elsewhere, or not at all

Created a release draft for `1.0.2`: https://github.com/cloudfour/fluidlint/releases/tag/untagged-205b0fa6ded899fcad4c