### PR TITLE
Add no-property-dash rule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fluidlint",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fluidlint",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "CLI that ensures that Liquid features that aren't supported by Fluid are not used.",
   "keywords": [],
   "author": "",

--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,17 @@ const rules = [
         severity: 'error'
       };
     }
+  },
+  tag => {
+    const params = tag.tagValue.split(/[\s,]+/).filter(p => p !== '');
+    if (params.some(p => p.endsWith(':') && p.includes('-'))) {
+      return {
+        ruleId: 'no-property-dash',
+        message: 'Properties should not have dashes',
+        source: tag.source,
+        severity: 'error'
+      };
+    }
   }
 ];
 


### PR DESCRIPTION
Disallows code like this:

```liquid
{% include 'asdf', asdf-asdf: 'asdf' %}
```